### PR TITLE
Fix formula label in schedule

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -218,7 +218,7 @@ function App() {
                   >
                     <div className="text-lg font-bold mb-2">{s.date}</div>
                     <div className="flex items-center space-x-1">
-                      <span className="font-medium">{formula}</span>
+                      <span className="font-medium">{results.formula}</span>
                       <span>{s.rate} ml/h × {results.duration}</span>
                     </div>
                     <div className="mt-1">ミルクプロテイン: {s.supp} 包</div>


### PR DESCRIPTION
## Summary
- fix formula display in day-by-day schedule

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68420ee68f54832c9d64bdedd98a4473