### PR TITLE
Enable vite build via build.js

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,1 +1,15 @@
-console.log('Build skipped: using existing dist directory');
+import { execSync } from 'child_process';
+import { existsSync, rmSync } from 'fs';
+
+const distDir = 'dist';
+
+if (existsSync(distDir)) {
+  rmSync(distDir, { recursive: true, force: true });
+}
+
+try {
+  execSync('npx vite build', { stdio: 'inherit' });
+} catch (err) {
+  console.error('Error during build:', err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- remove the old placeholder `build.js` implementation
- create a Node script that clears the `dist` directory and runs `vite build`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68426ed0fe4c832cb122172687add22c